### PR TITLE
feat: add environment configurations for production and development in wrangler.toml

### DIFF
--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -1,7 +1,6 @@
 # For more details on how to configure Wrangler, refer to:
 # https://developers.cloudflare.com/workers/wrangler/configuration/
 
-name = "pick-a-bots-2025"
 main = ".open-next/worker.js"
 compatibility_date = "2025-03-01"
 compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
@@ -12,6 +11,22 @@ directory = ".open-next/assets"
 
 [observability]
 enabled = true
+
+[env.prod]
+name = "pick-a-bots-2025"
+routes = [
+  { pattern = "pickabots.ramsocunsw.org", custom_domain = true },
+  { pattern = "www.pickabots.ramsocunsw.org", custom_domain = true }
+]
+
+[env.dev]
+name = "pick-a-bots-2025-dev"
+routes = [
+  { pattern = "pickabots.dev.ramsocunsw.org", custom_domain = true },
+  { pattern = "www.pickabots.dev.ramsocunsw.org", custom_domain = true }
+]
+
+
 
 
 # ----------------------------


### PR DESCRIPTION
## Description

This pull request updates the configuration file `frontend/wrangler.toml` to support multiple environments (`prod` and `dev`) for the Cloudflare Worker deployment. It introduces environment-specific settings, including unique names and routing patterns for production and development domains.

### Environment configuration updates:

* Added `[env.prod]` section with the name `pick-a-bots-2025` and routes for production domains (`pickabots.ramsocunsw.org` and `www.pickabots.ramsocunsw.org`).
* Added `[env.dev]` section with the name `pick-a-bots-2025-dev` and routes for development domains (`pickabots.dev.ramsocunsw.org` and `www.pickabots.dev.ramsocunsw.org`).

### General configuration adjustment:

* Removed the `name` field from the global scope and moved it into environment-specific sections (`[env.prod]` and `[env.dev]`).

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation or update

reference(notion|figma|issue): <https://www.notion.so/xxxxxxxxxxx>

## 📷 Screenshots (if any)

Mobile:

<!-- Drag and drop screenshots or screen recording -->

Desktop:

<!-- Drag and drop screenshots or screen recording -->

## Checklist

- [ ] I had tested the change locally (running `npm run preview`)
- [ ] Reviewed changes in both mobile and desktop by device
- [ ] My code changes follow the Code Style Guideline
- [ ] My PR title follows conventional change log standards
- [ ] I have included a screenshot (if it is an UI change)
