### PR TITLE
fix: leaderboard api to show self and top 10

### DIFF
--- a/frontend/src/app/api/leaderboard/route.ts
+++ b/frontend/src/app/api/leaderboard/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
 
     const { data, error } = await supabase
       .from("leaderboard")
-      .select("name, tokens, rank")
+      .select("name, tokens, rank, id")
       .order("rank", { ascending: true })
       .order("name", { ascending: true });
 
@@ -15,7 +15,28 @@ export async function GET() {
       throw new Error("No data found");
     }
 
-    return NextResponse.json(data);
+    const { data: authData, error: authError } = await supabase.auth.getUser();
+    if (authError) {
+      throw new Error("No user found");
+    }
+
+    const userId = authData.user?.id;
+    const userData = data.find((item) => item.id === userId);
+
+    const leaderboard = {
+      top: data.slice(0, 10).map((item) => ({
+        name: item.name,
+        points: item.tokens,
+        rank: item.rank,
+      })),
+      self: {
+        name: userData!.name,
+        points: userData!.tokens,
+        rank: userData!.rank,
+      },
+    };
+
+    return NextResponse.json(leaderboard);
   } catch (err) {
     console.error("Error fetching leaderboard:", err);
     return NextResponse.json(


### PR DESCRIPTION
## Description

This api is fixed to show the top 10 leaderboard and the rank of themself.

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bugfix (non-breaking change which fixes an issue)

## 📷 Screenshots (if any)

Mobile:

<!-- Drag and drop screenshots or screen recording -->

Desktop:

<!-- Drag and drop screenshots or screen recording -->

## Checklist

- [x] I had tested the change locally (running `npm run preview`)
- [x] Reviewed changes in both mobile and desktop by device
- [x] My code changes follow the Code Style Guideline
- [x] My PR title follows conventional change log standards
- [x] I have included a screenshot (if it is an UI change)
